### PR TITLE
Zmiana koloru czcionki dla elementów 'a'.

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -140,3 +140,7 @@
   position: relative;
   vertical-align: middle;
 }
+
+a {
+    color: #4a4a4a;
+}


### PR DESCRIPTION
Obecne ustawienie powoduje m.in. to, że opisy wyboru języka mają taki sam kolor jak tło.