### PR TITLE
Add Flask routing to simplify site build and ease local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Go to http://localhost:5000/en/ in the browser.
 
 ```bash
 python3 generate_sites.py
-python3 -m http.server
+python3 -m http.server --directory build
 ```
 
-Go to http://localhost:8000/build/en/ in the browser.
+Go to http://localhost:8000/en/ in the browser.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Commands:
 python3 -m venv venv
 source ./venv/bin/activate
 pip install -r requirements.txt
+./debug-app.py
+```
+
+Go to http://localhost:5000/en/ in the browser.
+
+## Build
+
+```bash
 python3 generate_sites.py
 python3 -m http.server
 ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,35 @@
+import os
+import json
+import flask
+import ruamel.yaml
+
+languages = ("pl", "uk", "en")
+
+yaml = ruamel.yaml.YAML()
+strings = yaml.load(
+    open("strings.yaml", mode="r", encoding="utf-8").read()
+)
+
+App = flask.Flask(__name__)
+
+@App.route('/')
+def get_index():
+    for lang in languages:
+        flask.url_for('get_language_index', lang=lang)
+        flask.url_for('get_language_mapjs', lang=lang)
+    return ''
+
+@App.route('/<lang>/index.html')
+@App.route('/<lang>/')
+def get_language_index(lang):
+    for point_id in points:
+        flask.url_for('get_point_permalink', lang=lang, point_id=point_id)
+    return flask.render_template('index.html', strings=strings, lang=lang)
+
+
+@App.route('/<lang>/map.js')
+def get_language_mapjs(lang):
+    return (
+        flask.render_template('map.js', strings=strings, lang=lang),
+        {'Content-Type': 'application/javascript'},
+    )

--- a/app.py
+++ b/app.py
@@ -15,24 +15,18 @@ App = flask.Flask(__name__)
 
 @App.route('/')
 def get_index():
-    for lang in languages:
-        flask.url_for('get_language_index', lang=lang)
-        flask.url_for('get_language_mapjs', lang=lang)
     return ''
 
 
 @App.route('/<lang>/index.html')
 @App.route('/<lang>/')
 def get_language_index(lang):
-    for point_id in points:
-        flask.url_for('get_point_permalink', lang=lang, point_id=point_id)
     return flask.render_template('index.html', strings=strings, lang=lang)
 
 
 
 @App.route('/<lang>/map.js')
 def get_language_mapjs(lang):
-    flask.url_for('get_osm_data_geojson')
     return (
         flask.render_template('map.js', strings=strings, lang=lang),
         {'Content-Type': 'application/javascript'},

--- a/app.py
+++ b/app.py
@@ -12,12 +12,14 @@ strings = yaml.load(
 
 App = flask.Flask(__name__)
 
+
 @App.route('/')
 def get_index():
     for lang in languages:
         flask.url_for('get_language_index', lang=lang)
         flask.url_for('get_language_mapjs', lang=lang)
     return ''
+
 
 @App.route('/<lang>/index.html')
 @App.route('/<lang>/')
@@ -27,9 +29,25 @@ def get_language_index(lang):
     return flask.render_template('index.html', strings=strings, lang=lang)
 
 
+
 @App.route('/<lang>/map.js')
 def get_language_mapjs(lang):
+    flask.url_for('get_osm_data_geojson')
     return (
         flask.render_template('map.js', strings=strings, lang=lang),
         {'Content-Type': 'application/javascript'},
     )
+
+
+@App.route('/data/osm_data.geojson')
+def get_osm_data_geojson():
+    if not os.path.exists("osm_data.geojson"):
+        return (
+            '{"type": "FeatureCollection", "features": []}',
+            {'Content-Type': 'application/octet-stream'},
+        )
+    with open("osm_data.geojson") as file:
+        return (
+            file.read(),
+            {'Content-Type': 'application/octet-stream'},
+        )

--- a/debug-app.py
+++ b/debug-app.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import app
+
+if __name__ == '__main__':
+    app.App.jinja_env.auto_reload = True
+    app.App.config['TEMPLATES_AUTO_RELOAD'] = True
+    app.App.run(debug=True)

--- a/generate_sites.py
+++ b/generate_sites.py
@@ -1,5 +1,14 @@
 import app
+import flask
 import flask_frozen
+
+
+@app.App.before_first_request
+def add_frozen_url_hints():
+    ''' Let Frozen-Flask know what entry point URLs should be generated.
+    '''
+    for lang in app.languages:
+        flask.url_for('get_language_index', lang=lang)
 
 
 if __name__ == "__main__":

--- a/generate_sites.py
+++ b/generate_sites.py
@@ -1,57 +1,6 @@
-import logging
-import shutil
-import sys
-from pathlib import Path
-
-from jinja2 import Environment, FileSystemLoader, select_autoescape
-from ruamel.yaml import YAML
-
-this_file_dir = Path(__file__).parent.resolve()
-
-logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__file__)
-logger.setLevel(logging.INFO)
-
-env = Environment(
-    loader=FileSystemLoader("templates"),
-    autoescape=select_autoescape()
-)
-
-languages = ("pl", "uk", "en")
-
-yaml = YAML()
-strings = yaml.load(
-    open(this_file_dir.joinpath("strings.yaml"), mode="r", encoding="utf-8").read()
-)
-
-
-def render_and_save(output_directory: Path, language: str) -> None:
-    for template_name in env.list_templates():
-        template = env.get_template(template_name)
-        rendered = template.render(lang=language, strings=strings)
-        with open(output_directory.joinpath(template_name), mode="w", encoding="utf-8") as out_file:
-            out_file.write(rendered)
+import app
+import flask_frozen
 
 
 if __name__ == "__main__":
-
-    default_dir = this_file_dir.joinpath("build").resolve()
-    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else default_dir
-    output_dir.mkdir(exist_ok=True)
-    static_dir = this_file_dir.joinpath("static").resolve()
-
-    # clean up output dir
-    shutil.rmtree(output_dir.joinpath("static"), ignore_errors=True)
-
-    # generate templates in all languages
-    for lang in languages:
-        lang_dir = output_dir.joinpath(lang)
-        shutil.rmtree(lang_dir, ignore_errors=True)
-        lang_dir.mkdir(exist_ok=True)
-        render_and_save(output_directory=lang_dir, language=lang)
-
-    # copy static files
-    shutil.copytree(
-        src=static_dir,
-        dst=output_dir.joinpath("static"),
-    )
+    flask_frozen.Freezer(app.App).freeze()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ ruamel.yaml==0.17.21
 ruamel.yaml.clib==0.2.6
 Shapely==1.8.1.post1
 urllib3==1.26.8
+Flask==2.0.1
+Frozen-Flask==0.14

--- a/templates/index.html
+++ b/templates/index.html
@@ -152,7 +152,7 @@
   </div>
 
   <div id="map"></div>
-  <script src="./map.js"></script>
+  <script src="{{ url_for('get_language_mapjs', lang=lang) }}"></script>
 
   <!-- Cloudflare Web Analytics -->
   <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "da4ec9500cd74c4c8a08c72a1d70f491"}'></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
   <script defer src="https://openingh.openstreetmap.de/opening_hours.js/opening_hours+deps.min.js"></script>
 
   <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css" rel="stylesheet"/>
-  <link href="../static/css/style.css" rel="stylesheet"/>
+  <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet"/>
 </head>
 <body>
 
@@ -59,21 +59,21 @@
 <!--        </div>-->
 
         <div class="navbar-item px-1">
-          <a class="" href="../uk/">
-            <img src="../static/img/flags/ua.png" height="26px" width="35px" class="mt-2 lang-img" alt="Ukrainian language">
+          <a class="" href="{{ url_for('get_language_index', lang='uk') }}">
+            <img src="{{ url_for('static', filename='img/flags/ua.png') }}" height="26px" width="35px" class="mt-2 lang-img" alt="Ukrainian language">
           </a>
         </div>
 
 
         <div class="navbar-item px-1">
-          <a class="" href="../pl/">
-            <img src="../static/img/flags/pl.png" height="26px"  width="35px"  class="mt-2 lang-img" alt="Polish language">
+          <a class="" href="{{ url_for('get_language_index', lang='pl') }}">
+            <img src="{{ url_for('static', filename='img/flags/pl.png') }}" height="26px"  width="35px"  class="mt-2 lang-img" alt="Polish language">
           </a>
         </div>
 
         <div class="navbar-item px-1">
-          <a class="" href="../en/">
-            <img src="../static/img/flags/gb.png" height="26px"  width="35px"  class="mt-2 lang-img" alt="English language">
+          <a class="" href="{{ url_for('get_language_index', lang='en') }}">
+            <img src="{{ url_for('static', filename='img/flags/gb.png') }}" height="26px"  width="35px"  class="mt-2 lang-img" alt="English language">
           </a>
         </div>
 

--- a/templates/map.js
+++ b/templates/map.js
@@ -1,7 +1,7 @@
 var language = '{{ lang }}';
 
 const customLayerURL = "{{ url_for('static', filename='custom.geojson') }}";
-const osmLayerURL = "../data/osm_data.geojson";
+const osmLayerURL = "{{ url_for('get_osm_data_geojson') }}";
 
 const textLayerDefaultLayoutParams = {
     'text-font': ['Open Sans Bold'],

--- a/templates/map.js
+++ b/templates/map.js
@@ -1,6 +1,6 @@
 var language = '{{ lang }}';
 
-const customLayerURL = "../static/custom.geojson";
+const customLayerURL = "{{ url_for('static', filename='custom.geojson') }}";
 const osmLayerURL = "../data/osm_data.geojson";
 
 const textLayerDefaultLayoutParams = {


### PR DESCRIPTION
Using Flask like this has two benefits:

1. It’s now possible to preview the site dynamically without complete rebuilds. Makes it faster to iteratively edit source.
2. Most custom site generation code in `generate_sites.py` has been replaced with built-in functionality from Frozen-Flask.