### PR TITLE
Exits with error code to catch issues, closes #3

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -135,6 +135,6 @@ if __name__ == "__main__":
 
     if not output_dir.is_dir():
         logger.error(f'Given path: "{output_dir}" is not a directory.')
-        sys.exit()
+        sys.exit(1) # exit with non-zero error code, see #3
 
     main(output_path=fp)


### PR DESCRIPTION
For #3.

By default `sys.exit()` exits successfully (code 0); we need an abnormal termination (i.e. non-zero exit code) for the shell and therefore Github Action to catch this error.

https://docs.python.org/3/library/sys.html#sys.exit