### PR TITLE
Fixes broken image link in metadata for Facebook

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
   <meta content="https://dopomoha.pl/{{ lang }}/" property="og:url">
   <meta property="og:title" content="{{ strings.title[lang] }}">
   <meta property="og:description" content="">
-  <meta property="og:image" content="https://dopomoha.pl/static/meta-image.png">
+  <meta property="og:image" content="https://dopomoha.pl/static/img/meta-image.png">
   
   <!-- Twitter Meta Tags -->
   <meta name="twitter:description" content="">


### PR DESCRIPTION
The meta image link was broken and was missing the img sub-directory.

This changeset fixes the link, so that Facebook will properly use the image we set in the metadata.

We do the same for Twitter a few lines below; it's the correct link there

https://github.com/openstreetmap-polska/ua-2022-map/blob/66c48f68cef740339e4065f0798cb07d2e04fe49/templates/index.html#L21