### PR TITLE
Deploy to static site server

### DIFF
--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - migurski/build-to-static-site
     paths-ignore:
       - README.md
       - .gitignore
@@ -35,3 +36,19 @@ jobs:
         run: |
           rsync --verbose --recursive --delete --exclude "data" -e "ssh -p ${{ secrets.SSH_HOST_PORT }}" \
             ./build/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST_IP }}:/var/www/html/
+  deploy-static:
+    name: Deploy to static env
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pip install -r requirements.txt --upgrade pip awscli
+      - name: Generate from templates
+        run: python generate_sites.py
+      - name: Deploy site with aws s3
+        run: |
+          aws s3 sync ./build/ s3://${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/deploy_to_prod.yaml
+++ b/.github/workflows/deploy_to_prod.yaml
@@ -47,6 +47,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: pip install -r requirements.txt --upgrade pip awscli
+      - name: Download OSM data
+        run: python download_data.py
       - name: Generate from templates
         run: python generate_sites.py
       - name: Deploy site with aws s3

--- a/app.py
+++ b/app.py
@@ -15,7 +15,18 @@ App = flask.Flask(__name__)
 
 @App.route('/')
 def get_index():
-    return ''
+    return '''<!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <title></title>
+            <meta http-equiv="Refresh" content="0; url='/uk/#map=7/50.538/24.055'" />
+        </head>
+        <body>
+
+        </body>
+        </html>
+    '''
 
 
 @App.route('/<lang>/index.html')


### PR DESCRIPTION
In email conversation with Włodzimierz Bartczak I learned that OSM-PL is worried about attacks on the site after start of promotion. Static site hosting on a large service such as Amazon S3 with a CDN like Cloudfront can protect against most foreseeable attacks. This draft PR demonstrates how the site can be deployed to a static site host.

In this example, we deploy to a bucket visible online at https://dopomoha.teczno.com.

See https://github.com/migurski/ua-2022-map/runs/5370557331 for the latest successful run. 

To keep the data up-to-date, AWS and other cloud hosts support scheduled tasks that can run `download_data.py` periodically.