### PR TITLE
Specify Minimum Python 3 Version as 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ pip install -r requirements.txt
 
 Go to http://localhost:8000/en/ in the browser.
 
+## Minimum System Requirements
+
+Python 3.7 or greater
+
 ## Build
 
 ```bash


### PR DESCRIPTION
Please specify the minimum Python 3 version in the README.

My first time downloading and setting up the project failed with the following error:

```
> pip install -r requirements.txt 
Requirement already satisfied: certifi==2021.10.8 in ./venv/lib/python3.6/site-packages (from -r requirements.txt (line 1)) (2021.10.8)
Requirement already satisfied: charset-normalizer==2.0.12 in ./venv/lib/python3.6/site-packages (from -r requirements.txt (line 2)) (2.0.12)
Requirement already satisfied: idna==3.3 in ./venv/lib/python3.6/site-packages (from -r requirements.txt (line 3)) (3.3)
Requirement already satisfied: Jinja2==3.0.3 in ./venv/lib/python3.6/site-packages (from -r requirements.txt (line 4)) (3.0.3)
ERROR: Could not find a version that satisfies the requirement MarkupSafe==2.1.0 (from versions: 0.9, 0.9.1, 0.9.2, 0.9.3, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 1.0, 1.1.0, 1.1.1, 2.0.0a1, 2.0.0rc1, 2.0.0rc2, 2.0.0, 2.0.1)
ERROR: No matching distribution found for MarkupSafe==2.1.0
```

This was a confusing error because MarkupSafe clearly shows a v2.1.0 release: https://pypi.org/project/MarkupSafe/#history
After navigating to the MarkupSafe project repository, I searched through the revision history and discovered that they dropped support for Python 3.6 starting with MarkupSafe version 2.1.0: https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-1 

My laptop was using Python 3.6 which explains why I couldn't download the requirements. After upgrading my Python to version 3.7, installing requirements.txt succeeds. 